### PR TITLE
Fix metric aggregate names.

### DIFF
--- a/django_usaid_clinicfinder/clinicfinder/tasks.py
+++ b/django_usaid_clinicfinder/clinicfinder/tasks.py
@@ -207,7 +207,7 @@ class Location_Sender(Task):
                         l.info("Sent message to <%s>" % response["to_addr"])
                         metric_sender.delay(
                             metric="sms.results",
-                            value=1, agg="SUM")
+                            value=1, agg="sum")
                     else:
                         l.info(
                             "Message not sent to <%s>. "
@@ -221,7 +221,7 @@ class Location_Sender(Task):
                            response["to_addr"])
                     metric_sender.delay(
                             metric="sms.noresults",
-                            value=1, agg="SUM")
+                            value=1, agg="sum")
                 lookuppoi.save()
 
                 return vumiresponse
@@ -364,4 +364,3 @@ class PointOfInterest_Importer(Task):
                 exc_info=True)
 
 pointofinterest_importer = PointOfInterest_Importer()
-

--- a/django_usaid_clinicfinder/requirements.txt
+++ b/django_usaid_clinicfinder/requirements.txt
@@ -13,4 +13,4 @@ suds==0.4
 celery
 django-celery
 redis
-go-http==0.2.2
+go-http==0.3.0


### PR DESCRIPTION
Currently uppercase aggregate names are used. They should be lowercase (and recent versions of the `go_http` library complain if uppercase names are used in tests with the logging sender).
